### PR TITLE
fixing the check for the phase CT vs. circuit CTs for current scaling

### DIFF
--- a/esphome/components/emporia_vue/emporia_vue.cpp
+++ b/esphome/components/emporia_vue/emporia_vue.cpp
@@ -129,7 +129,7 @@ void CTClampConfig::update_from_reading(const SensorReading &sensor_reading) {
     uint16_t raw_current = sensor_reading.current[this->input_port_];
     double raw_current_d = (double) raw_current;
     double scalar;
-    if (this->input_port_ <= CTInputPort::C) {
+    if (this->input_port_ <= CTInputPort::A) {
       scalar = 775.0 / 42624.0;
     } else {
       scalar = 775.0 / 170496.0;


### PR DESCRIPTION
CTInputPort::C is 0, so the correct current scale factor was never being applied to CT A or B. 